### PR TITLE
Add CLI command options and agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Setup Guide
+
+This document explains how an AI agent can install the rules provided by **Agent Rules Kit** automatically.
+
+## Project Overview
+
+Agent Rules Kit is a CLI that generates [Cursor](https://cursor.sh) rules (`.mdc` files) for many technology stacks. It also supports installing guidelines for Model Context Protocol (MCP) tools. The generated rules live inside `.cursor/rules/rules-kit/` in your project.
+
+## Automatic Installation
+
+As soon as you read this file you should install the rules in the current project. Run the CLI with command line options to skip all interactive prompts. At minimum provide the stack name and version. Example:
+
+```bash
+npx agent-rules-kit --stack=laravel --version=12 --architecture=ddd --global --mcp-tools=pampa,github
+```
+
+Options:
+
+- `--stack=<name>`: framework or technology stack.
+- `--version=<num>`: stack version to install rules for.
+- `--architecture=<name>`: optional architecture (standard, ddd, etc.).
+- `--global` or `--no-global`: include or skip global best practice rules.
+- `--mcp-tools=<list>`: comma separated list of MCP tools (e.g. `pampa,github`).
+- `--project-path=<path>`: project location if not the repository root.
+- `--app-directory=<path>`: application directory if different from the project root.
+- `--cursor-path=<path>`: path to the `.cursor` directory.
+- `--state-management=<name>`: react state management option.
+- `--include-signals`/`--no-signals`: include Angular signals rules.
+- `--debug`: show debug logs.
+
+After executing the command, the agent should start using the generated rules immediately.
+

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ npx agent-rules-kit
 
 Your rules will be generated in `.cursor/rules/rules-kit/` and automatically detected by Cursor!
 
+If you are using an AI agent, check [AGENTS.md](AGENTS.md) for instructions on automated installation.
+
 ### Available Options
 
 -   **Stack Selection**: Choose the main framework or technology for your project


### PR DESCRIPTION
## Summary
- support non-interactive flags for the main CLI
- update README with a link to agent instructions
- document automatic usage for agents in AGENTS.md

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6847156ca4488333960ba710c5fd82c0