### PR TITLE
Add Node.js base docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ MCP tools rules work alongside your stack-specific rules:
 | <img src="https://img.shields.io/badge/Astro-0D0D0D?style=for-the-badge&logo=astro&logoColor=white" alt="Astro" width="100"/>                    | ![60%](https://progress-bar.dev/60)   | Content collections, static/dynamic content, integration guides                                                                |
 | <img src="https://img.shields.io/badge/Angular-DD0031?style=for-the-badge&logo=angular&logoColor=white" alt="Angular" width="100"/>              | ![55%](https://progress-bar.dev/55)   | Signals support, base project structure                                                                                        |
 | <img src="https://img.shields.io/badge/NestJS-E0234E?style=for-the-badge&logo=nestjs&logoColor=white" alt="NestJS" width="100"/>                 | ![75%](https://progress-bar.dev/75)   | Standard and Microservices architectures, NestJS 9.x and 10.x features                                                         |
+| <img src="https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js" width="100"/>              | ![20%](https://progress-bar.dev/20)   | Base project structure, best practices, naming, testing |
 | <img src="https://img.shields.io/badge/Vue-4FC08D?style=for-the-badge&logo=vue.js&logoColor=white" alt="Vue" width="100"/>                       | ![45%](https://progress-bar.dev/45)   | Testing guidelines, architecture concepts                                                                                      |
 | <img src="https://img.shields.io/badge/Spring%20Boot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white" alt="Spring Boot" width="100"/> | ![100%](https://progress-bar.dev/100) | Standard, Reactive, Microservices                                                                                              |
 
@@ -257,6 +258,7 @@ Choose from a wide range of technology stacks:
 | **Go**                              | 1.20, 1.21, 1.22                            | Standard, DDD, Hexagonal              |
 | **Django**                          | 4, 5                                        | MVT, API, Full-Stack                  |
 | **FastAPI**                         | 0.100+                                      | Standard, Async, Microservices        |
+| **Node.js**                         | 18, 20 | Standard                              |
 | **Express.js**                      | 4                                           | Standard, REST, GraphQL               |
 | **Spring Boot**                     | 2, 3                                        | Standard, Reactive, Microservices     |
 | **🆕 MCP (Model Context Protocol)** | Python, TypeScript, Java, Kotlin, C#, Swift | Server, Client, Toolkit               |

--- a/templates/kit-config.json
+++ b/templates/kit-config.json
@@ -96,34 +96,58 @@
 			}
 		}
 	},
-	"nestjs": {
-		"default_architecture": "standard",
-		"version_ranges": {
-			"9": {
-				"name": "NestJS 9-10",
-				"range_name": "v9-10"
-			},
-			"10": {
-				"name": "NestJS 9-10",
-				"range_name": "v9-10"
-			}
-		},
-		"architectures": {
-			"standard": {
-				"name": "Standard Architecture",
-				"globs": ["<root>/src/**/*.ts"]
-			},
-			"ddd": {
-				"name": "Domain-Driven Design",
-				"globs": ["<root>/src/**/*.ts"]
-			}
-		}
-	},
-	"react": {
-		"default_architecture": "standard",
-		"version_ranges": {
-			"17": {
-				"name": "React 17",
+        "nestjs": {
+                "default_architecture": "standard",
+                "version_ranges": {
+                        "9": {
+                                "name": "NestJS 9-10",
+                                "range_name": "v9-10"
+                        },
+                        "10": {
+                                "name": "NestJS 9-10",
+                                "range_name": "v9-10"
+                        }
+                },
+                "architectures": {
+                        "standard": {
+                                "name": "Standard Architecture",
+                                "globs": ["<root>/src/**/*.ts"]
+                        },
+                        "ddd": {
+                                "name": "Domain-Driven Design",
+                                "globs": ["<root>/src/**/*.ts"]
+                        }
+                }
+        },
+        "nodejs": {
+                "default_architecture": "standard",
+                "version_ranges": {
+                        "18": {
+                                "name": "Node.js 18",
+                                "range_name": "v18"
+                        },
+                        "20": {
+                                "name": "Node.js 20",
+                                "range_name": "v20"
+                        }
+                },
+                "globs": [
+                        "<root>/src/**/*.{js,ts}",
+                        "<root>/**/*.js",
+                        "<root>/**/*.ts"
+                ],
+                "architectures": {
+                        "standard": {
+                                "name": "Standard Node.js Architecture",
+                                "globs": ["<root>/src/**/*.{js,ts}"]
+                        }
+                }
+        },
+        "react": {
+                "default_architecture": "standard",
+                "version_ranges": {
+                        "17": {
+                                "name": "React 17",
 				"range_name": "v17"
 			},
 			"18": {

--- a/templates/stacks/nodejs/base/architecture-concepts.md
+++ b/templates/stacks/nodejs/base/architecture-concepts.md
@@ -1,0 +1,34 @@
+---
+description: Architecture concepts for Node.js applications
+globs: <root>/src/**/*.{js,ts},<root>/**/*.js,<root>/**/*.ts
+alwaysApply: false
+---
+
+# Node.js Architecture Concepts
+
+Node.js is built on the V8 JavaScript engine and relies on an event-driven, non-blocking I/O model. The runtime executes JavaScript in a single process while using the **libuv** library to delegate operations such as file and network access to the system. This design allows highly concurrent applications without managing multiple threads.
+
+## Typical Project Structure
+
+A common folder layout separates concerns by layers:
+
+```text
+src/
+├── controllers/   # HTTP or RPC handlers
+├── services/      # Business logic
+├── repositories/  # Database access
+├── lib/           # Reusable modules
+└── index.js       # Application entry point
+```
+
+Environment-specific configuration is usually loaded from `.env` files using `process.env`. Prefer dependency injection for testability and use environment variables to switch between development and production settings.
+
+## Modules
+
+Node.js supports both **CommonJS** (`require`) and **ECMAScript modules** (`import`). Choose one style consistently across the project. ECMAScript modules are recommended for new code as they align with modern JavaScript standards.
+
+## Concurrency and Scaling
+
+Each Node.js process handles work via the event loop. For CPU-bound tasks or higher throughput, spawn multiple processes using the **cluster** module or an external process manager such as PM2. Horizontal scaling is typically achieved by running multiple instances behind a load balancer.
+
+For more details, see the official [Node.js documentation](https://nodejs.org/en/docs/).

--- a/templates/stacks/nodejs/base/best-practices.md
+++ b/templates/stacks/nodejs/base/best-practices.md
@@ -1,0 +1,36 @@
+---
+description: Best practices for Node.js projects
+globs: <root>/src/**/*.{js,ts},<root>/**/*.js,<root>/**/*.ts
+alwaysApply: true
+---
+
+# Node.js Best Practices
+
+The following recommendations help keep Node.js applications secure and maintainable.
+
+## Dependency Management
+
+- Use **pnpm** or **npm** to install packages and lock dependencies with `package-lock.json` or `pnpm-lock.yaml`.
+- Keep dependencies up to date and prefer Long Term Support (LTS) versions of Node.js.
+
+## Asynchronous Programming
+
+- Leverage `async`/`await` for readable asynchronous code.
+- Avoid callback hell by returning Promises whenever possible.
+
+## Configuration Handling
+
+- Load environment variables from `.env` files using packages such as `dotenv`.
+- Store secrets outside of the repository and access them through `process.env`.
+
+## Error Handling
+
+- Catch and log errors in asynchronous flows using try/catch blocks.
+- Send meaningful HTTP status codes and messages when building APIs.
+
+## Security Guidelines
+
+- Sanitize user input to prevent injection attacks (see [Node.js Security Best Practices](https://nodejs.org/en/docs/guides/security/)).
+- Regularly audit dependencies with `npm audit` or `pnpm audit`.
+
+For more details, consult the [official Node.js guides](https://nodejs.org/en/docs/guides/).

--- a/templates/stacks/nodejs/base/naming-conventions.md
+++ b/templates/stacks/nodejs/base/naming-conventions.md
@@ -1,0 +1,17 @@
+---
+description: Naming conventions for Node.js
+globs: <root>/src/**/*.{js,ts},<root>/**/*.js,<root>/**/*.ts
+alwaysApply: false
+---
+
+# Node.js Naming Conventions
+
+Follow these conventions for a consistent codebase.
+
+- **Variables and functions**: use `camelCase`.
+- **Classes and constructors**: use `PascalCase`.
+- **File and directory names**: prefer `kebab-case` or lowercase with dashes.
+- **Constants and environment variables**: use `UPPER_SNAKE_CASE`.
+- Avoid spaces or accented characters in filenames.
+
+For more guidance, see the [Node.js style guide](https://github.com/nodejs/node/blob/main/doc/guides/contributing/writing-tests.md#naming).

--- a/templates/stacks/nodejs/base/testing.md
+++ b/templates/stacks/nodejs/base/testing.md
@@ -1,0 +1,22 @@
+---
+description: Testing strategies for Node.js
+globs: <root>/test/**/*.{js,ts},<root>/tests/**/*.{js,ts}
+alwaysApply: false
+---
+
+# Node.js Testing
+
+Use dedicated test folders such as `test/` or `tests/`. Node.js ships with a built-in test runner via `node:test`, but frameworks like **Jest** or **Mocha** offer additional features such as mocks and coverage reports.
+
+## Example with node:test
+
+```javascript
+import test from 'node:test';
+import assert from 'node:assert';
+
+test('sum adds numbers', () => {
+        assert.equal(1 + 2, 3);
+});
+```
+
+Run tests with `node --test` and generate coverage with `--test --coverage`.

--- a/templates/stacks/nodejs/base/version-info.md
+++ b/templates/stacks/nodejs/base/version-info.md
@@ -1,0 +1,9 @@
+---
+description: Version information for Node.js applications
+globs: <root>/package.json
+alwaysApply: true
+---
+
+# Node.js Version Information
+
+This project is using Node.js **{detectedVersion}**. Both 18 and 20 are active Long Term Support releases. Use `node --version` to verify the runtime and refer to the [release schedule](https://nodejs.org/en/about/releases) for maintenance dates.


### PR DESCRIPTION
## Summary
- expand Node.js stack base documentation

## Testing
- `pnpm run lint` *(fails: configuration uses legacy format)*
- `pnpm run test`
- `pnpx agent-rules-kit --update`


------
https://chatgpt.com/codex/tasks/task_e_6850085259ac8333a9c32847ab8e50d1