### PR TITLE
Fix globs format in templates

### DIFF
--- a/templates/mcp-tools/filesystem/filesystem-mcp-usage.md
+++ b/templates/mcp-tools/filesystem/filesystem-mcp-usage.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/mcp-tools/git/git-mcp-usage.md
+++ b/templates/mcp-tools/git/git-mcp-usage.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/mcp-tools/github/github-mcp-usage.md
+++ b/templates/mcp-tools/github/github-mcp-usage.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/mcp-tools/memory/memory-mcp-usage.md
+++ b/templates/mcp-tools/memory/memory-mcp-usage.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/mcp-tools/pampa/pampa-mcp-usage.md
+++ b/templates/mcp-tools/pampa/pampa-mcp-usage.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/stacks/angular/base/version-info.md
+++ b/templates/stacks/angular/base/version-info.md
@@ -1,6 +1,6 @@
 ---
 description: Version information for Angular applications
-globs: <root>/src/**/*.{ts,html,scss,css},<root>/angular.json
+globs: <root>/src/**/*.ts,<root>/src/**/*.html,<root>/src/**/*.scss,<root>/src/**/*.css,<root>/angular.json
 alwaysApply: true
 ---
 

--- a/templates/stacks/astro/base/version-info.md
+++ b/templates/stacks/astro/base/version-info.md
@@ -1,6 +1,6 @@
 ---
 description: Version information for Astro applications
-globs: <root>/src/**/*.astro,<root>/src/**/*.{md,mdx},<root>/package.json,<root>/astro.config.{js,mjs,ts}
+globs: <root>/src/**/*.astro,<root>/src/**/*.md,<root>/src/**/*.mdx,<root>/package.json,<root>/astro.config.js,<root>/astro.config.mjs,<root>/astro.config.ts
 alwaysApply: true
 ---
 

--- a/templates/stacks/mcp/architectures/server/server-implementation.md
+++ b/templates/stacks/mcp/architectures/server/server-implementation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.{py,ts,js,java,kt,cs,swift}']
+globs: <root>/**/*.py,<root>/**/*.ts,<root>/**/*.js,<root>/**/*.java,<root>/**/*.kt,<root>/**/*.cs,<root>/**/*.swift
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/base/architecture-concepts.md
+++ b/templates/stacks/mcp/base/architecture-concepts.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.{py,ts,js,java,kt,cs,swift}']
+globs: <root>/**/*.py,<root>/**/*.ts,<root>/**/*.js,<root>/**/*.java,<root>/**/*.kt,<root>/**/*.cs,<root>/**/*.swift
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/base/best-practices.md
+++ b/templates/stacks/mcp/base/best-practices.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.{py,ts,js,java,kt,cs,swift}']
+globs: <root>/**/*.py,<root>/**/*.ts,<root>/**/*.js,<root>/**/*.java,<root>/**/*.kt,<root>/**/*.cs,<root>/**/*.swift
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/csharp/csharp-sdk-implementation.md
+++ b/templates/stacks/mcp/csharp/csharp-sdk-implementation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.cs', '<root>/*.csproj', '<root>/*.sln']
+globs: <root>/**/*.cs,<root>/*.csproj,<root>/*.sln
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/java/java-sdk-implementation.md
+++ b/templates/stacks/mcp/java/java-sdk-implementation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.java', '<root>/pom.xml', '<root>/build.gradle']
+globs: <root>/**/*.java,<root>/pom.xml,<root>/build.gradle
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/kotlin/kotlin-sdk-implementation.md
+++ b/templates/stacks/mcp/kotlin/kotlin-sdk-implementation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.kt', '<root>/build.gradle.kts', '<root>/build.gradle']
+globs: <root>/**/*.kt,<root>/build.gradle.kts,<root>/build.gradle
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/python/python-sdk-implementation.md
+++ b/templates/stacks/mcp/python/python-sdk-implementation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.py', '<root>/pyproject.toml', '<root>/requirements.txt']
+globs: <root>/**/*.py,<root>/pyproject.toml,<root>/requirements.txt
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/swift/swift-sdk-implementation.md
+++ b/templates/stacks/mcp/swift/swift-sdk-implementation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*.swift', '<root>/Package.swift', '<root>/*.xcodeproj']
+globs: <root>/**/*.swift,<root>/Package.swift,<root>/*.xcodeproj
 alwaysApply: false
 ---
 

--- a/templates/stacks/mcp/typescript/typescript-sdk-implementation.md
+++ b/templates/stacks/mcp/typescript/typescript-sdk-implementation.md
@@ -1,11 +1,5 @@
 ---
-globs:
-    [
-        '<root>/**/*.ts',
-        '<root>/**/*.js',
-        '<root>/package.json',
-        '<root>/tsconfig.json',
-    ]
+globs: <root>/**/*.ts,<root>/**/*.js,<root>/package.json,<root>/tsconfig.json
 alwaysApply: false
 ---
 

--- a/templates/stacks/nextjs/architectures/app/app-router.md
+++ b/templates/stacks/nextjs/architectures/app/app-router.md
@@ -1,6 +1,6 @@
 ---
 description: App Router architecture guidelines for Next.js 13+
-globs: <root>/app/**/*.{ts,tsx}
+globs: <root>/app/**/*.ts,<root>/app/**/*.tsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/nextjs/architectures/pages/pages-router.md
+++ b/templates/stacks/nextjs/architectures/pages/pages-router.md
@@ -1,6 +1,6 @@
 ---
 description: Pages Router architecture guidelines for Next.js
-globs: <root>/pages/**/*.{ts,tsx}
+globs: <root>/pages/**/*.ts,<root>/pages/**/*.tsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/nextjs/base/architecture-concepts.md
+++ b/templates/stacks/nextjs/base/architecture-concepts.md
@@ -1,6 +1,6 @@
 ---
 description: Core architectural concepts for Next.js applications
-globs: <root>/app/**/*.{ts,tsx},<root>/src/**/*.{ts,tsx},<root>/pages/api/**/*.ts,<root>/tests/**/*.{ts,tsx}
+globs: <root>/app/**/*.ts,<root>/app/**/*.tsx,<root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/pages/api/**/*.ts,<root>/tests/**/*.ts,<root>/tests/**/*.tsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/nextjs/base/best-practices.md
+++ b/templates/stacks/nextjs/base/best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Core best practices for Next.js applications
-globs: <root>/app/**/*.{ts,tsx},<root>/components/**/*.{ts,tsx},<root>/pages/**/*.{ts,tsx}
+globs: <root>/app/**/*.ts,<root>/app/**/*.tsx,<root>/components/**/*.ts,<root>/components/**/*.tsx,<root>/pages/**/*.ts,<root>/pages/**/*.tsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/nextjs/base/naming-conventions.md
+++ b/templates/stacks/nextjs/base/naming-conventions.md
@@ -1,6 +1,6 @@
 ---
 description: Naming conventions for Next.js applications
-globs: <root>/app/**/*.{ts,tsx},<root>/src/**/*.{ts,tsx},<root>/pages/**/*.{ts,tsx},<root>/components/**/*.{ts,tsx}
+globs: <root>/app/**/*.ts,<root>/app/**/*.tsx,<root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/pages/**/*.ts,<root>/pages/**/*.tsx,<root>/components/**/*.ts,<root>/components/**/*.tsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/nextjs/base/testing-best-practices.md
+++ b/templates/stacks/nextjs/base/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing best practices for Next.js applications
-globs: <root>/app/**/*.{ts,tsx},<root>/src/**/*.{ts,tsx},<root>/pages/api/**/*.ts,<root>/tests/**/*.{ts,tsx}
+globs: <root>/app/**/*.ts,<root>/app/**/*.tsx,<root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/pages/api/**/*.ts,<root>/tests/**/*.ts,<root>/tests/**/*.tsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/nextjs/base/version-info.md
+++ b/templates/stacks/nextjs/base/version-info.md
@@ -1,6 +1,6 @@
 ---
 description: Version information for Next.js applications
-globs: <root>/app/**/*.{ts,tsx},<root>/src/**/*.{ts,tsx},<root>/pages/**/*.{ts,tsx},<root>/next.config.{js,ts}
+globs: <root>/app/**/*.ts,<root>/app/**/*.tsx,<root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/pages/**/*.ts,<root>/pages/**/*.tsx,<root>/next.config.js,<root>/next.config.ts
 alwaysApply: true
 ---
 

--- a/templates/stacks/nuxt/architectures/standard/standard-nuxt-architecture.md
+++ b/templates/stacks/nuxt/architectures/standard/standard-nuxt-architecture.md
@@ -1,6 +1,6 @@
 ---
 description: Standard Architecture for Nuxt applications
-globs: <root>/nuxt.config.{js,ts},<root>/pages/**/*.{vue,js,ts},<root>/components/**/*.{vue,js,ts}
+globs: <root>/nuxt.config.js,<root>/nuxt.config.ts,<root>/pages/**/*.vue,<root>/pages/**/*.js,<root>/pages/**/*.ts,<root>/components/**/*.vue,<root>/components/**/*.js,<root>/components/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/nuxt/base/architecture-concepts.md
+++ b/templates/stacks/nuxt/base/architecture-concepts.md
@@ -1,6 +1,6 @@
 ---
 description: Core architectural concepts for Nuxt applications
-globs: <root>/app.vue,<root>/components/**/*.{vue,ts,js}
+globs: <root>/app.vue,<root>/components/**/*.vue,<root>/components/**/*.ts,<root>/components/**/*.js
 alwaysApply: false
 ---
 

--- a/templates/stacks/nuxt/base/best-practices.md
+++ b/templates/stacks/nuxt/base/best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Best practices for Nuxt applications
-globs: <root>/app.vue,<root>/components/**/*.{vue,ts,js}
+globs: <root>/app.vue,<root>/components/**/*.vue,<root>/components/**/*.ts,<root>/components/**/*.js
 alwaysApply: false
 ---
 

--- a/templates/stacks/nuxt/base/naming-conventions.md
+++ b/templates/stacks/nuxt/base/naming-conventions.md
@@ -1,6 +1,6 @@
 ---
 description: Naming conventions for Nuxt applications
-globs: <root>/app.vue,<root>/components/**/*.{vue,ts,js}
+globs: <root>/app.vue,<root>/components/**/*.vue,<root>/components/**/*.ts,<root>/components/**/*.js
 alwaysApply: false
 ---
 

--- a/templates/stacks/nuxt/base/testing-best-practices.md
+++ b/templates/stacks/nuxt/base/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing best practices for Nuxt applications
-globs: <root>/tests/**/*.{spec,test}.{ts,js}
+globs: <root>/tests/**/*.spec.ts,<root>/tests/**/*.spec.js,<root>/tests/**/*.test.ts,<root>/tests/**/*.test.js
 alwaysApply: false
 ---
 

--- a/templates/stacks/nuxt/base/version-info.md
+++ b/templates/stacks/nuxt/base/version-info.md
@@ -1,6 +1,6 @@
 ---
 description: Version information for Nuxt applications
-globs: <root>/nuxt.config.{js,ts},<root>/package.json
+globs: <root>/nuxt.config.js,<root>/nuxt.config.ts,<root>/package.json
 alwaysApply: true
 ---
 

--- a/templates/stacks/nuxt/v2/nuxt2-features.md
+++ b/templates/stacks/nuxt/v2/nuxt2-features.md
@@ -1,6 +1,6 @@
 ---
 description: Nuxt 2 specific features and best practices
-globs: <root>/nuxt.config.{js,ts},<root>/pages/**/*.{vue,js,ts}
+globs: <root>/nuxt.config.js,<root>/nuxt.config.ts,<root>/pages/**/*.vue,<root>/pages/**/*.js,<root>/pages/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/nuxt/v2/testing-best-practices.md
+++ b/templates/stacks/nuxt/v2/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing implementation examples for Nuxt 2
-globs: <root>/test/**/*.{spec,test}.{js,ts}
+globs: <root>/test/**/*.spec.js,<root>/test/**/*.spec.ts,<root>/test/**/*.test.js,<root>/test/**/*.test.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/nuxt/v3/testing-best-practices.md
+++ b/templates/stacks/nuxt/v3/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing implementation examples for Nuxt 3
-globs: <root>/tests/**/*.{spec,test}.{ts,js}
+globs: <root>/tests/**/*.spec.ts,<root>/tests/**/*.spec.js,<root>/tests/**/*.test.ts,<root>/tests/**/*.test.js
 alwaysApply: false
 ---
 

--- a/templates/stacks/pampa/architectures/standard/installation.md
+++ b/templates/stacks/pampa/architectures/standard/installation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/stacks/pampa/base/pampa-concepts.md
+++ b/templates/stacks/pampa/base/pampa-concepts.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/stacks/pampa/base/pampa-implementation.md
+++ b/templates/stacks/pampa/base/pampa-implementation.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/stacks/pampa/base/pampa-mcp-rules.md
+++ b/templates/stacks/pampa/base/pampa-mcp-rules.md
@@ -1,5 +1,5 @@
 ---
-globs: ['<root>/**/*']
+globs: <root>/**/*
 alwaysApply: false
 ---
 

--- a/templates/stacks/react/architectures/atomic/atomic-architecture.md
+++ b/templates/stacks/react/architectures/atomic/atomic-architecture.md
@@ -1,6 +1,6 @@
 ---
 description: Atomic Design architecture for React applications
-globs: <root>/src/**/*.{ts,tsx,js,jsx}
+globs: <root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/react/architectures/feature-sliced/feature-sliced-architecture.md
+++ b/templates/stacks/react/architectures/feature-sliced/feature-sliced-architecture.md
@@ -1,6 +1,6 @@
 ---
 description: Feature-Sliced Design architecture for React applications
-globs: <root>/src/**/*.{ts,tsx,js,jsx}
+globs: <root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/react/base/architecture-concepts.md
+++ b/templates/stacks/react/base/architecture-concepts.md
@@ -1,6 +1,6 @@
 ---
 description: Core architectural concepts for React applications
-globs: <root>/src/**/*.{ts,tsx,js,jsx}
+globs: <root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/react/base/best-practices.md
+++ b/templates/stacks/react/base/best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Best practices for React applications
-globs: <root>/src/**/*.{ts,tsx,js,jsx},<root>/components/**/*.{ts,tsx,js,jsx}
+globs: <root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx,<root>/components/**/*.ts,<root>/components/**/*.tsx,<root>/components/**/*.js,<root>/components/**/*.jsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/react/base/naming-conventions.md
+++ b/templates/stacks/react/base/naming-conventions.md
@@ -1,6 +1,6 @@
 ---
 description: Naming conventions for React applications
-globs: <root>/src/**/*.{ts,tsx,js,jsx},<root>/components/**/*.{ts,tsx,js,jsx}
+globs: <root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx,<root>/components/**/*.ts,<root>/components/**/*.tsx,<root>/components/**/*.js,<root>/components/**/*.jsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/react/base/testing-best-practices.md
+++ b/templates/stacks/react/base/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing best practices for React applications
-globs: <root>/src/**/*.{ts,tsx,js,jsx},<root>/tests/**/*.{ts,tsx,js,jsx}
+globs: <root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx,<root>/tests/**/*.ts,<root>/tests/**/*.tsx,<root>/tests/**/*.js,<root>/tests/**/*.jsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/react/base/version-info.md
+++ b/templates/stacks/react/base/version-info.md
@@ -1,6 +1,6 @@
 ---
 description: Version information for React applications
-globs: <root>/package.json,<root>/src/**/*.{ts,tsx,js,jsx}
+globs: <root>/package.json,<root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx
 alwaysApply: true
 ---
 

--- a/templates/stacks/react/state-management/redux/redux-guide.md
+++ b/templates/stacks/react/state-management/redux/redux-guide.md
@@ -1,6 +1,6 @@
 ---
 description: Guide for using Redux state management in React applications
-globs: <root>/src/**/*.{ts,tsx,js,jsx}
+globs: <root>/src/**/*.ts,<root>/src/**/*.tsx,<root>/src/**/*.js,<root>/src/**/*.jsx
 alwaysApply: false
 ---
 

--- a/templates/stacks/svelte/base/architecture-concepts.md
+++ b/templates/stacks/svelte/base/architecture-concepts.md
@@ -1,6 +1,6 @@
 ---
 description: Core architectural concepts for Svelte applications
-globs: <root>/src/**/*.svelte,<root>/src/**/*.{js,ts}
+globs: <root>/src/**/*.svelte,<root>/src/**/*.js,<root>/src/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/svelte/base/best-practices.md
+++ b/templates/stacks/svelte/base/best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Best practices for Svelte applications
-globs: <root>/src/**/*.svelte,<root>/src/**/*.{js,ts}
+globs: <root>/src/**/*.svelte,<root>/src/**/*.js,<root>/src/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/svelte/base/naming-conventions.md
+++ b/templates/stacks/svelte/base/naming-conventions.md
@@ -1,6 +1,6 @@
 ---
 description: Naming conventions for Svelte applications
-globs: <root>/src/**/*.svelte,<root>/src/**/*.{js,ts}
+globs: <root>/src/**/*.svelte,<root>/src/**/*.js,<root>/src/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/svelte/base/testing-best-practices.md
+++ b/templates/stacks/svelte/base/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing best practices for Svelte applications
-globs: <root>/src/**/*.spec.{js,ts},<root>/tests/**/*.{js,ts}
+globs: <root>/src/**/*.spec.js,<root>/src/**/*.spec.ts,<root>/tests/**/*.js,<root>/tests/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/sveltekit/base/architecture-concepts.md
+++ b/templates/stacks/sveltekit/base/architecture-concepts.md
@@ -1,6 +1,6 @@
 ---
 description: Core architectural concepts for SvelteKit applications
-globs: <root>/src/**/*.svelte,<root>/src/routes/**/*.{js,ts,svelte}
+globs: <root>/src/**/*.svelte,<root>/src/routes/**/*.js,<root>/src/routes/**/*.ts,<root>/src/routes/**/*.svelte
 alwaysApply: false
 ---
 

--- a/templates/stacks/sveltekit/base/best-practices.md
+++ b/templates/stacks/sveltekit/base/best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Best practices for SvelteKit applications
-globs: <root>/src/**/*.svelte,<root>/src/routes/**/*.{js,ts,svelte}
+globs: <root>/src/**/*.svelte,<root>/src/routes/**/*.js,<root>/src/routes/**/*.ts,<root>/src/routes/**/*.svelte
 alwaysApply: false
 ---
 

--- a/templates/stacks/sveltekit/base/naming-conventions.md
+++ b/templates/stacks/sveltekit/base/naming-conventions.md
@@ -1,6 +1,6 @@
 ---
 description: Naming conventions for SvelteKit applications
-globs: <root>/src/**/*.svelte,<root>/src/routes/**/*.{js,ts,svelte}
+globs: <root>/src/**/*.svelte,<root>/src/routes/**/*.js,<root>/src/routes/**/*.ts,<root>/src/routes/**/*.svelte
 alwaysApply: false
 ---
 

--- a/templates/stacks/sveltekit/base/testing-best-practices.md
+++ b/templates/stacks/sveltekit/base/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing best practices for SvelteKit applications
-globs: <root>/src/**/*.spec.{js,ts},<root>/tests/**/*.{js,ts}
+globs: <root>/src/**/*.spec.js,<root>/src/**/*.spec.ts,<root>/tests/**/*.js,<root>/tests/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/vue/base/bes-practices.md
+++ b/templates/stacks/vue/base/bes-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Best practices for Vue applications
-globs: <root>/src/**/*.vue,<root>/src/**/*.{js,ts}
+globs: <root>/src/**/*.vue,<root>/src/**/*.js,<root>/src/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/vue/base/naming-conventions.md
+++ b/templates/stacks/vue/base/naming-conventions.md
@@ -1,6 +1,6 @@
 ---
 description: Naming conventions for Vue applications
-globs: <root>/src/**/*.vue,<root>/src/**/*.{js,ts}
+globs: <root>/src/**/*.vue,<root>/src/**/*.js,<root>/src/**/*.ts
 alwaysApply: false
 ---
 

--- a/templates/stacks/vue/base/testing-best-practices.md
+++ b/templates/stacks/vue/base/testing-best-practices.md
@@ -1,6 +1,6 @@
 ---
 description: Testing best practices for Vue applications
-globs: <root>/src/**/*.spec.{js,ts},<root>/tests/**/*.{js,ts}
+globs: <root>/src/**/*.spec.js,<root>/src/**/*.spec.ts,<root>/tests/**/*.js,<root>/tests/**/*.ts
 alwaysApply: false
 ---
 


### PR DESCRIPTION
## Summary
- ensure every Markdown rule file lists `globs` as plain text
- expand brace patterns to individual paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850138ffdac8333b81d1b543443d792