### PR TITLE
Fix architecture file naming

### DIFF
--- a/cli/services/stack-service.js
+++ b/cli/services/stack-service.js
@@ -884,7 +884,7 @@ export class StackService extends BaseService {
                 const archFiles = await fs.promises.readdir(archDir);
                 for (const file of archFiles) {
                     if (file.endsWith('.md')) {
-                        const baseName = file;
+                        const baseName = `architecture-${architecture}-${file}`;
                         if (!trackedFiles.has(baseName)) {
                             trackedFiles.set(baseName, []);
                         }
@@ -1172,7 +1172,7 @@ export class StackService extends BaseService {
             if (await this.pathExistsAsync(archDir)) {
                 const archFiles = await fs.promises.readdir(archDir);
                 archFiles.filter(file => file.endsWith('.md')).forEach(file => {
-                    trackedFiles.add(file);
+                    trackedFiles.add(`architecture-${architecture}-${file}`);
                 });
             }
         }

--- a/tests/test-cli.test.js
+++ b/tests/test-cli.test.js
@@ -56,6 +56,7 @@ describe('Test CLI Integration', () => {
         expect(laravelFiles).toContain('architecture-concepts.mdc');
         expect(laravelFiles).toContain('best-practices.mdc');
         expect(laravelFiles).toContain('version-info.mdc');
+        expect(laravelFiles).toContain('architecture-standard-structure.mdc');
     }, 10000);
 
     test('should generate Angular rules correctly', async () => {
@@ -79,6 +80,48 @@ describe('Test CLI Integration', () => {
         expect(angularFiles).toContain('architecture-concepts.mdc');
         expect(angularFiles).toContain('best-practices.mdc');
         expect(angularFiles).toContain('version-info.mdc');
+    }, 10000);
+
+    test('should generate Laravel DDD architecture rules', async () => {
+        const command = `node "${testCliPath}" --stack=laravel --version=11 --architecture=ddd --root=${testOutputDir}`;
+
+        const { stdout, stderr } = await execAsync(command);
+
+        expect(stderr).toBe('');
+        expect(stdout).toContain('✅ Test completed');
+
+        const laravelDir = path.join(testOutputDir, '.cursor', 'rules', 'rules-kit', 'laravel');
+        const laravelFiles = await fs.readdir(laravelDir);
+
+        expect(laravelFiles).toContain('architecture-ddd-structure.mdc');
+    }, 10000);
+
+    test('should generate NestJS microservices architecture rules', async () => {
+        const command = `node "${testCliPath}" --stack=nestjs --version=9 --architecture=microservices --root=${testOutputDir}`;
+
+        const { stdout, stderr } = await execAsync(command);
+
+        expect(stderr).toBe('');
+        expect(stdout).toContain('✅ Test completed');
+
+        const nestDir = path.join(testOutputDir, '.cursor', 'rules', 'rules-kit', 'nestjs');
+        const nestFiles = await fs.readdir(nestDir);
+
+        expect(nestFiles).toContain('architecture-microservices-microservices-architecture.mdc');
+    }, 10000);
+
+    test('should generate Next.js app router architecture rules', async () => {
+        const command = `node \"${testCliPath}\" --stack=nextjs --version=14 --architecture=app --root=${testOutputDir}`;
+
+        const { stdout, stderr } = await execAsync(command);
+
+        expect(stderr).toBe('');
+        expect(stdout).toContain('✅ Test completed');
+
+        const nextDir = path.join(testOutputDir, '.cursor', 'rules', 'rules-kit', 'nextjs');
+        const nextFiles = await fs.readdir(nextDir);
+
+        expect(nextFiles).toContain('architecture-app-app-router.mdc');
     }, 10000);
 
     test('should generate only global rules when no stack specified', async () => {


### PR DESCRIPTION
## Summary
- handle architecture file names in stack service
- test architecture rule generation for Laravel, NestJS and Next.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850151afc688333bc7091d2db6172bd